### PR TITLE
Double quotes fixed, and added a closing paren.

### DIFF
--- a/lib/hamlbars/template.rb
+++ b/lib/hamlbars/template.rb
@@ -49,7 +49,7 @@ module Hamlbars
       if basename =~ /^_/
         <<-REG
 (function() {
-  Handlebars.registerPartial("#{scope.logical_path.inspect}", "#{indent(template)}";
+  Handlebars.registerPartial(#{scope.logical_path.inspect}, "#{indent(template)}");
 }).call(this);
         REG
       else


### PR DESCRIPTION
Other possible change: scope.logical_path.inspect to scope.logical_path.inspect.gsub("/",".")

Since the above would be something like "templates/posts/_new", and doing "{{>templates/posts/_new}}" in handlebars gets interpreted as "templates.posts._new". So, having partials saved that way behind the scenes might be easier.
